### PR TITLE
Update stellar-hd-wallet link to version 0.0.2

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 </p>
 
 <ol>
-  <li>Download <code>stellar-hd-wallet</code> from Stellar GitHub: <a href="https://github.com/stellar/go/releases/tag/stellar-hd-wallet-v0.0.1">https://github.com/stellar/go/releases/tag/stellar-hd-wallet-v0.0.1</a></li>
+  <li>Download <code>stellar-hd-wallet</code> from Stellar GitHub: <a href="https://github.com/stellar/go/releases/tag/stellar-hd-wallet-v0.0.2">https://github.com/stellar/go/releases/tag/stellar-hd-wallet-v0.0.2</a></li>
   <li>Unpack a downloaded zip file.</li>
   <li>Open a terminal window and navigate to a folder where the archive was unpacked.</li>
   <li>


### PR DESCRIPTION
This updates the Stellar paper wallet deprecation notice so it links to version 0.0.2 of the stellar-hd-wallet